### PR TITLE
Set a fixed width for input fields in constant nodes

### DIFF
--- a/src/stylesheets/node/content.sass
+++ b/src/stylesheets/node/content.sass
@@ -11,6 +11,7 @@
     background-color: $content-base-color
     border: 2px solid $content-border-color
     border-radius: 4px
+    width: 50px
     color: $font-color
     &::selection
       background-color: $dim-highlight-color


### PR DESCRIPTION
This will make it so they take up less space on screen because 20 digits 
of space is unnecessary because they won't be used and will take up 
screen space. Space for 4 or 5 digits is enough (and more can be typed, 
just with scrolling)